### PR TITLE
Fix editor styling for dark and futuristic themes

### DIFF
--- a/src/components/editor/CodeEditor.tsx
+++ b/src/components/editor/CodeEditor.tsx
@@ -6,6 +6,7 @@ import { markdown } from '@codemirror/lang-markdown';
 import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
 import { Decoration, DecorationSet, ViewPlugin, ViewUpdate } from '@codemirror/view';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface Variable {
   name: string;
@@ -72,50 +73,102 @@ function createVariableHighlighter(variables: Variable[]): Extension {
 }
 
 export function CodeEditor({ value, onChange, variables }: CodeEditorProps) {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark' || resolvedTheme === 'futuristic';
+
   const handleChange = useCallback((val: string) => {
     onChange(val);
   }, [onChange]);
 
   const extensions = useMemo(() => {
+    // Theme-aware colors
+    const theme = isDark ? {
+      background: resolvedTheme === 'futuristic' ? 'hsl(240, 10%, 5%)' : 'hsl(222.2, 84%, 4.9%)',
+      foreground: resolvedTheme === 'futuristic' ? 'hsl(180, 100%, 90%)' : 'hsl(210, 40%, 98%)',
+      gutter: resolvedTheme === 'futuristic' ? 'hsl(240, 10%, 8%)' : 'hsl(217.2, 32.6%, 12%)',
+      activeGutter: resolvedTheme === 'futuristic' ? 'hsl(240, 10%, 10%)' : 'hsl(217.2, 32.6%, 15%)',
+      selection: resolvedTheme === 'futuristic' ? 'hsl(180, 100%, 50%, 0.15)' : 'hsl(217.2, 91.2%, 59.8%, 0.15)',
+      activeLine: resolvedTheme === 'futuristic' ? 'hsl(240, 10%, 7%)' : 'hsl(217.2, 32.6%, 10%)',
+      variableDefined: {
+        bg: resolvedTheme === 'futuristic' ? 'rgba(0, 255, 255, 0.1)' : 'rgba(59, 130, 246, 0.15)',
+        color: resolvedTheme === 'futuristic' ? 'hsl(180, 100%, 60%)' : 'rgb(96, 165, 250)',
+      },
+      variableUndefined: {
+        bg: resolvedTheme === 'futuristic' ? 'rgba(255, 0, 100, 0.1)' : 'rgba(239, 68, 68, 0.15)',
+        color: resolvedTheme === 'futuristic' ? 'hsl(330, 100%, 60%)' : 'rgb(248, 113, 113)',
+      },
+    } : {
+      background: 'hsl(0, 0%, 100%)',
+      foreground: 'hsl(222.2, 84%, 4.9%)',
+      gutter: 'hsl(210, 40%, 98%)',
+      activeGutter: 'hsl(210, 40%, 96%)',
+      selection: 'hsl(221.2, 83.2%, 53.3%, 0.1)',
+      activeLine: 'hsl(210, 40%, 98%)',
+      variableDefined: {
+        bg: 'rgba(59, 130, 246, 0.1)',
+        color: 'rgb(59, 130, 246)',
+      },
+      variableUndefined: {
+        bg: 'rgba(239, 68, 68, 0.1)',
+        color: 'rgb(239, 68, 68)',
+      },
+    };
+
     return [
       markdown(),
       createVariableHighlighter(variables),
       EditorView.lineWrapping,
       EditorView.theme({
+        '&': {
+          fontSize: '14px',
+          backgroundColor: theme.background,
+          color: theme.foreground,
+        },
+        '.cm-content': {
+          minHeight: '300px',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+          caretColor: theme.foreground,
+        },
+        '.cm-cursor, .cm-dropCursor': {
+          borderLeftColor: theme.foreground,
+        },
+        '&.cm-focused .cm-selectionBackground, ::selection': {
+          backgroundColor: theme.selection,
+        },
+        '.cm-activeLine': {
+          backgroundColor: theme.activeLine,
+        },
+        '.cm-gutters': {
+          backgroundColor: theme.gutter,
+          color: theme.foreground,
+          border: 'none',
+        },
+        '.cm-activeLineGutter': {
+          backgroundColor: theme.activeGutter,
+        },
+        '.cm-lineNumbers .cm-gutterElement': {
+          color: isDark ? 'hsl(215, 20.2%, 65.1%)' : 'hsl(215.4, 16.3%, 46.9%)',
+        },
         '.cm-variable-defined': {
-          backgroundColor: 'rgba(59, 130, 246, 0.1)',
-          color: 'rgb(59, 130, 246)',
+          backgroundColor: theme.variableDefined.bg,
+          color: theme.variableDefined.color,
           fontWeight: '500',
           borderRadius: '3px',
           padding: '1px 2px',
         },
         '.cm-variable-undefined': {
-          backgroundColor: 'rgba(239, 68, 68, 0.1)',
-          color: 'rgb(239, 68, 68)',
+          backgroundColor: theme.variableUndefined.bg,
+          color: theme.variableUndefined.color,
           fontWeight: '500',
           borderRadius: '3px',
           padding: '1px 2px',
         },
-        '&': {
-          fontSize: '14px',
-        },
-        '.cm-content': {
-          minHeight: '300px',
-          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-        },
-        '.cm-gutters': {
-          backgroundColor: 'rgb(249, 250, 251)',
-          border: 'none',
-        },
-        '.cm-activeLineGutter': {
-          backgroundColor: 'rgb(243, 244, 246)',
-        },
-      }),
+      }, { dark: isDark }),
     ];
-  }, [variables]);
+  }, [variables, isDark, resolvedTheme]);
 
   return (
-    <div className="border rounded-md overflow-hidden">
+    <div className="border rounded-md overflow-hidden border-border">
       <CodeMirror
         value={value}
         onChange={handleChange}

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -55,13 +55,13 @@ export function MarkdownPreview({ content }: MarkdownPreviewProps) {
               ),
             blockquote: ({ node, ...props }) => (
               <blockquote
-                className="border-l-4 border-blue-500 pl-4 italic my-2 text-muted-foreground"
+                className="border-l-4 border-primary pl-4 italic my-2 text-muted-foreground"
                 {...props}
               />
             ),
             a: ({ node, ...props }) => (
               <a
-                className="text-blue-600 hover:underline"
+                className="text-primary hover:underline"
                 target="_blank"
                 rel="noopener noreferrer"
                 {...props}
@@ -69,14 +69,14 @@ export function MarkdownPreview({ content }: MarkdownPreviewProps) {
             ),
             table: ({ node, ...props }) => (
               <div className="overflow-x-auto my-2">
-                <table className="min-w-full border-collapse border border-gray-300" {...props} />
+                <table className="min-w-full border-collapse border border-border" {...props} />
               </div>
             ),
             th: ({ node, ...props }) => (
-              <th className="border border-gray-300 px-3 py-2 bg-muted font-semibold text-left text-sm" {...props} />
+              <th className="border border-border px-3 py-2 bg-muted font-semibold text-left text-sm" {...props} />
             ),
             td: ({ node, ...props }) => (
-              <td className="border border-gray-300 px-3 py-2 text-sm" {...props} />
+              <td className="border border-border px-3 py-2 text-sm" {...props} />
             ),
           }}
         >


### PR DESCRIPTION
Fixed issue where the code editor and markdown preview had poor contrast in dark and futuristic themes.

Changes:
- Updated CodeEditor component to be theme-aware:
  - Added useTheme hook to detect current theme
  - Applied theme-specific colors for editor background, foreground, gutters
  - Enhanced variable highlighting colors for each theme
  - Added proper cursor and selection colors
  - Fixed line number visibility in dark themes
  - Applied CodeMirror dark mode flag for dark/futuristic themes

- Updated MarkdownPreview component:
  - Changed hardcoded blue colors to use primary theme color
  - Changed gray borders to use border theme variable
  - Now properly inherits theme colors via Tailwind classes

The editor now provides proper contrast and readability in all three themes (Light, Dark, and Futuristic), with theme-appropriate syntax highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)